### PR TITLE
waited for all pods ready during generated hashring initialization

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,7 @@ linters:
   - perfsprint
   - maligned
   - gosec
+  - gocognit
 
 linters-settings:
   errcheck:

--- a/main.go
+++ b/main.go
@@ -580,7 +580,7 @@ func (c *controller) sync(ctx context.Context) {
 
 				if err := c.waitForPod(ctx, podName); err != nil {
 					level.Warn(c.logger).Log("msg", "failed polling until pod is ready", "pod", podName, "duration", time.Since(start), "err", err)
-					continue
+					return
 				}
 
 				level.Debug(c.logger).Log("msg", "waited until new pod was ready", "pod", podName, "duration", time.Since(start))


### PR DESCRIPTION
During the initial controller setup, we prefer to wait over all pods ready before generating hashring.

Deployed in our integrationtest cluster, found 
1. it will wait for all pods ready before generating hashring for first time
2. else will be no-op if not all pods are ready and replicas do not exist in the local
This is to handle no replicas information stored in local controller after controller restarts, we should not do anything until the cluster is healthy.